### PR TITLE
Add optional title filter to /items query

### DIFF
--- a/backend/routes/api/items.js
+++ b/backend/routes/api/items.js
@@ -71,6 +71,10 @@ router.get("/", auth.optional, function(req, res, next) {
         query._id = { $in: [] };
       }
 
+      if (req.query.title) {
+        query.title = new RegExp(`.*${req.query.title}.*`, 'i')
+      }
+
       return Promise.all([
         Item.find(query)
           .limit(Number(limit))


### PR DESCRIPTION
# Description

Add optional `title` param to `/items` query. This value will be used to filter items by title
- the query should filter all items that contain the given title text
- the query should be case insensitive

This change will allow for the implementation of a search bar on the frontend
